### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "Chore: "
+    labels:
+      - github_actions
+      - dependabot
+      - chore


### PR DESCRIPTION
This PR adds a basic Dependabot configuration for GitHub Actions.

Links to intenthq/infrastructure#6834